### PR TITLE
Fix usage of Config (instead of RbConfig) to allow building on ruby trunk

### DIFF
--- a/ext/hitimes/extconf.rb
+++ b/ext/hitimes/extconf.rb
@@ -1,10 +1,10 @@
 require 'rbconfig'
 require 'mkmf'
 
-if Config::CONFIG['host_os'] =~ /darwin/ then
+if RbConfig::CONFIG['host_os'] =~ /darwin/ then
   $CFLAGS += " -DUSE_INSTANT_OSX=1 -Wall"
   $LDFLAGS += " -framework CoreServices"
-elsif Config::CONFIG['host_os'] =~ /win32/ or Config::CONFIG['host_os'] =~ /mingw/ then
+elsif RbConfig::CONFIG['host_os'] =~ /win32/ or RbConfig::CONFIG['host_os'] =~ /mingw/ then
   $CFLAGS += " -DUSE_INSTANT_WINDOWS=1"
 else
   if have_library("rt", "clock_gettime") then

--- a/tasks/extension.rake
+++ b/tasks/extension.rake
@@ -21,7 +21,7 @@ if ext_config = Configuration.for_if_exist?('extension') then
           subdir = "hitimes/#{RUBY_VERSION.sub(/\.\d$/,'')}"
           dest_dir = Hitimes::Paths.lib_path( subdir )
           mkdir_p dest_dir, :verbose => true
-          cp "hitimes_ext.#{Config::CONFIG['DLEXT']}", dest_dir, :verbose => true
+          cp "hitimes_ext.#{RbConfig::CONFIG['DLEXT']}", dest_dir, :verbose => true
         end
       end
     end 
@@ -31,7 +31,7 @@ if ext_config = Configuration.for_if_exist?('extension') then
       task :build_java => [ :clobber, "lib/hitimes/hitimes.jar" ]
 
       file "lib/hitimes/hitimes.jar" => FileList["ext/java/src/hitimes/*.java"] do |t|
-        jruby_home = Config::CONFIG['prefix']
+        jruby_home = RbConfig::CONFIG['prefix']
         jruby_jar  = File.join( jruby_home, 'lib', 'jruby.jar' )
 
         mkdir_p 'pkg/classes'


### PR DESCRIPTION
Hello,

The `Config` alias for `RbConfig` has been removed in ruby trunk.
It has been deprecated since 2010 and was there only for 1.8.4 compatibility, so I think it's safe using only `RbConfig`.

This means the gem won't install and fail with `uninitialized constant Config`.
Could you merge this and release the gem?

Thank you for this nice gem!
