### PR TITLE
update OS X absolute time documentation link

### DIFF
--- a/ext/hitimes/c/hitimes_instant_osx.c
+++ b/ext/hitimes/c/hitimes_instant_osx.c
@@ -4,7 +4,7 @@
 #include <mach/mach.h>
 #include <mach/mach_time.h>
 
-/* All this OSX code is adapted from http://developer.apple.com/library/mac/#qa/qa1398/_index.html */
+/* All this OSX code is adapted from https://developer.apple.com/library/archive/qa/qa1398/_index.html */
 
 /*
  * returns the conversion factor, this value is used to convert


### PR DESCRIPTION
Hi, 

Looks like Apple moved a lot of QA stuff to archive now. It wasn't very hard to find, but it would be nicer to have a correct link :)