### PR TITLE
don't use static (global) runtime state

### DIFF
--- a/ext/hitimes/java/src/hitimes/Hitimes.java
+++ b/ext/hitimes/java/src/hitimes/Hitimes.java
@@ -28,15 +28,14 @@ public class Hitimes {
 
     public static final double INSTANT_CONVERSION_FACTOR = 1000000000d;
 
-    private static final Ruby __ruby__ = Ruby.getGlobalRuntime();
-
     public static RubyClass hitimesIntervalClass;
+    
     /**
      * Create the Hitimes module and add it to the Ruby runtime.
      */
     public static RubyModule createHitimesModule( Ruby runtime ) {
         RubyModule mHitimes = runtime.defineModule("Hitimes");
-        mHitimes.defineConstant("INSTANT_CONVERSION_FACTOR", __ruby__.newFloat(INSTANT_CONVERSION_FACTOR));
+        mHitimes.defineConstant("INSTANT_CONVERSION_FACTOR", runtime.newFloat(INSTANT_CONVERSION_FACTOR));
         mHitimes.defineAnnotatedMethods( Hitimes.class );
 
         RubyClass  cStandardError = runtime.getStandardError();
@@ -59,8 +58,8 @@ public class Hitimes {
 
 
     @JRubyMethod( name = "raw_instant", module = true )
-    public static IRubyObject rawInstant(IRubyObject self) {
-      return __ruby__.newFixnum( System.nanoTime() );
+    public static IRubyObject rawInstant(ThreadContext context, IRubyObject self) {
+        return context.runtime.newFixnum( System.nanoTime() );
     }
 
 }

--- a/ext/hitimes/java/src/hitimes/Hitimes.java
+++ b/ext/hitimes/java/src/hitimes/Hitimes.java
@@ -3,20 +3,18 @@ package hitimes;
 import java.lang.Math;
 import java.lang.System;
 
-import org.jruby.anno.JRubyClass;
-import org.jruby.anno.JRubyMethod;
-import org.jruby.anno.JRubyModule;
-import org.jruby.anno.JRubyConstant;
-import org.jruby.runtime.Visibility;
-
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyException;
 import org.jruby.RubyModule;
 import org.jruby.RubyObject;
-
+import org.jruby.anno.JRubyClass;
+import org.jruby.anno.JRubyMethod;
+import org.jruby.anno.JRubyModule;
+import org.jruby.anno.JRubyConstant;
 import org.jruby.exceptions.RaiseException;
-
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
 
 


### PR DESCRIPTION
always do operations relative to actual runtime (as there might be plenty in a single JVM)