### PR TITLE
fix: Use Minitest must_raise correctly and handle error message

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,7 @@ easiest way to contribute.
 
 * Jeremy Hinegardner
 * Wojciech Piekutowski
+* Mamoru TASAKA
 
 [GitHub Account]: https://github.com/signup/free "GitHub Signup"
 [GitHub Issues]:  https://github.com/copiousfreetime/hitimes/issues "Hitimes Issues"

--- a/spec/initialize_spec.rb
+++ b/spec/initialize_spec.rb
@@ -14,8 +14,9 @@ describe "Hitimes::Initialize" do
   end
 
   it "should raise an error if no clock id is found" do
-    _(lambda {
+    ex = _(lambda {
         Hitimes::Initialize.determine_clock_id([])
-      }).must_raise(Hitimes::Error, /Unable to find a high resolution clock/)
+      }).must_raise(Hitimes::Error)
+    assert_match(/Unable to find a high resolution clock/, ex.message)
   end
 end

--- a/spec/initialize_spec.rb
+++ b/spec/initialize_spec.rb
@@ -15,8 +15,8 @@ describe "Hitimes::Initialize" do
 
   it "should raise an error if no clock id is found" do
     ex = _(lambda {
-        Hitimes::Initialize.determine_clock_id([])
-      }).must_raise(Hitimes::Error)
+      Hitimes::Initialize.determine_clock_id([])
+    }).must_raise(Hitimes::Error)
     assert_match(/Unable to find a high resolution clock/, ex.message)
   end
 end

--- a/spec/interval_spec.rb
+++ b/spec/interval_spec.rb
@@ -5,14 +5,16 @@ require "spec_helper"
 describe Hitimes::Interval do
   it "raises an error if duration is called on a non-started interval" do
     i = Hitimes::Interval.new
-    _(lambda {
+    ex = _(lambda {
         i.duration
-      }).must_raise(Hitimes::Error, /\AAttempt to report a duration on an interval that has not started\Z/)
+      }).must_raise(Hitimes::Error)
+    assert_match(/\AAttempt to report a duration on an interval that has not started\Z/, ex.message)
   end
 
   it "raises an error if stop is called on a non-started interval" do
     i = Hitimes::Interval.new
-    _(-> { i.stop }).must_raise(Hitimes::Error, /\AAttempt to stop an interval that has not started\Z/)
+    ex = _(-> { i.stop }).must_raise(Hitimes::Error)
+    assert_match(/\AAttempt to stop an interval that has not started\Z/, ex.message)
   end
 
   it "knows if it has been started" do
@@ -48,7 +50,8 @@ describe Hitimes::Interval do
   end
 
   it "raises an error if measure is called with no block" do
-    _(-> { Hitimes::Interval.measure }).must_raise(Hitimes::Error, /\ANo block given to Interval.measure\Z/)
+    ex = _(-> { Hitimes::Interval.measure }).must_raise(Hitimes::Error)
+    assert_match(/\ANo block given to Interval.measure\Z/, ex.message)
   end
 
   it "creates an interval via #now" do

--- a/spec/interval_spec.rb
+++ b/spec/interval_spec.rb
@@ -6,8 +6,8 @@ describe Hitimes::Interval do
   it "raises an error if duration is called on a non-started interval" do
     i = Hitimes::Interval.new
     ex = _(lambda {
-        i.duration
-      }).must_raise(Hitimes::Error)
+      i.duration
+    }).must_raise(Hitimes::Error)
     assert_match(/\AAttempt to report a duration on an interval that has not started\Z/, ex.message)
   end
 


### PR DESCRIPTION
`must_raise` is sort of the alias for `assert_raises`, and actually https://github.com/minitest/minitest/blob/v6.0.5/lib/minitest/assertions.rb#L390 says that `assert_raises` can take an optional "message" (i.e. string) to help explain failures, so not regex or so to test if assertion message matches it.

Up to Minitest 6.0.4, when passing regex for `assert_raises` it was simply ignored, ref:

https://github.com/minitest/minitest/issues/1068
https://bugs.ruby-lang.org/issues/22007

Now Minitest 6.0.5 explicitly refuses this usage as: https://github.com/minitest/minitest/commit/6790f86f894637768a1f64cfe50959d2029b65ed and now `must_raise` also refuses this usage.

Closes #91 .

**Note**

This was originally in #92 and I needed to move it to a fresh PR so that that CI would run.